### PR TITLE
Update NiceBox-360.py

### DIFF
--- a/NiceBox-360.py
+++ b/NiceBox-360.py
@@ -775,10 +775,11 @@ def saveToDXF(sketch, name):
 
                     
 def run(context):
-    ui = None
     try:
         global app, ui, box
-        
+
+        ui = None
+
         app = adsk.core.Application.get()
         ui  = app.userInterface
         box = BOX()


### PR DESCRIPTION
for python 3.7.3

autodesk has updated python version to 3.7.3 used in fusion360.

python3.7.3 reject global definition of a variable is None.

I think this patch does not impact a existing function but I welcome your option.